### PR TITLE
Fix PhotoFragment Crash and Update Version

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="17" />
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2024-07-14T11:19:01.129591500Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=39121JEHN07237" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
-</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,16 +4,16 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="PLATFORM" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,52 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="NullableNotNullManager">
+    <option name="myDefaultNullable" value="androidx.annotation.Nullable" />
+    <option name="myDefaultNotNull" value="androidx.annotation.NonNull" />
+    <option name="myNullables">
+      <value>
+        <list size="15">
+          <item index="0" class="java.lang.String" itemvalue="org.jspecify.annotations.Nullable" />
+          <item index="1" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
+          <item index="3" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="4" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
+          <item index="6" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
+          <item index="7" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="8" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+          <item index="9" class="java.lang.String" itemvalue="jakarta.annotation.Nullable" />
+          <item index="10" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="11" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="12" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="13" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
+          <item index="14" class="java.lang.String" itemvalue="android.annotation.Nullable" />
+        </list>
+      </value>
+    </option>
+    <option name="myNotNulls">
+      <value>
+        <list size="14">
+          <item index="0" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
+          <item index="1" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="2" class="java.lang.String" itemvalue="org.jspecify.annotations.NonNull" />
+          <item index="3" class="java.lang.String" itemvalue="jakarta.annotation.Nonnull" />
+          <item index="4" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
+          <item index="5" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
+          <item index="6" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+          <item index="7" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
+          <item index="8" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="10" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="11" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="12" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
+          <item index="13" class="java.lang.String" itemvalue="android.annotation.NonNull" />
+        </list>
+      </value>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,9 +3,10 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
-        <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
-        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
-        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
       </set>
     </option>
   </component>

--- a/app/.idea/workspace.xml
+++ b/app/.idea/workspace.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="NONE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="a18d7e89-ff45-48e9-8e70-04b85a245159" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/../.idea/codeStyles/Project.xml" beforeDir="false" afterPath="$PROJECT_DIR$/../.idea/codeStyles/Project.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../.idea/gradle.xml" beforeDir="false" afterPath="$PROJECT_DIR$/../.idea/gradle.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/../.idea/misc.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../.idea/runConfigurations.xml" beforeDir="false" />
+      <change beforePath="$PROJECT_DIR$/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/AndroidManifest.xml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/AndroidManifest.xml" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$/.." />
+  </component>
+  <component name="ProjectId" id="2ZBQekKb10GU2ZPoHlx2A9JUs97" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.cidr.known.project.marker": "true",
+    "android.gradle.sync.needed": "true",
+    "cidr.known.project.marker": "true",
+    "dart.analysis.tool.window.visible": "false",
+    "last_opened_file_path": "C:/Users/Maja/Desktop/Maja/android-studio-projects/astro-app/build.gradle",
+    "show.migrate.to.gradle.popup": "false"
+  }
+}]]></component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="a18d7e89-ff45-48e9-8e70-04b85a245159" name="Changes" comment="" />
+      <created>1701893090337</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1701893090337</updated>
+    </task>
+    <servers />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,8 @@ def keystoreProperties = new Properties()
 keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 
 android {
+    namespace = "com.udacity.astroapp"
+
     signingConfigs {
         config {
             keyAlias keystoreProperties['keyAlias']
@@ -17,12 +19,12 @@ android {
             storePassword keystoreProperties['storePassword']
         }
     }
-    compileSdk 34
+    compileSdk 35
     defaultConfig {
         resConfigs "hr", "en"
         applicationId "com.udacity.astroapp"
         minSdkVersion 19
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 31
         versionName "1.0.0+$versionCode"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'androidx.fragment:fragment-testing:1.7.1'
     implementation 'androidx.fragment:fragment:1.7.1'
-    implementation files('libs/YouTubeAndroidPlayerApi.jar')
+    implementation 'com.pierfrancescosoffritti.androidyoutubeplayer:core:12.1.1'
     androidTestImplementation 'com.21buttons:fragment-test-rule:1.0.0'
     debugImplementation 'com.21buttons:fragment-test-rule-extras:2.0.1'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "com.udacity.astroapp"
         minSdkVersion 19
         targetSdkVersion 35
-        versionCode 31
-        versionName "1.0.0+$versionCode"
+        versionCode 32
+        versionName "1.0.1+$versionCode"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,8 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
 
     <application
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.udacity.astroapp">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -19,9 +18,9 @@
         <activity
             android:name=".activities.MainActivity"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize"
+            android:exported="true"
             android:launchMode="singleTask"
-            android:theme="@style/AppTheme.NoActionBar"
-            android:exported="true">
+            android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -46,7 +45,8 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
-        <receiver android:name=".data.AstroAppWidget"
+        <receiver
+            android:name=".data.AstroAppWidget"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/app/src/main/java/com/udacity/astroapp/fragments/PhotoFragment.java
+++ b/app/src/main/java/com/udacity/astroapp/fragments/PhotoFragment.java
@@ -669,7 +669,10 @@ public class PhotoFragment extends Fragment {
             dialog.dismiss();
         });
 
-        dialog.setOnDismissListener(dialog -> isDialogShown = false);
+        dialog.setOnDismissListener(dialog -> {
+            isDialogShown = false;
+            fullScreenVideoPlayerView.release();
+        });
     }
 
     public void setLoadingView() {

--- a/app/src/main/java/com/udacity/astroapp/fragments/PhotoFragment.java
+++ b/app/src/main/java/com/udacity/astroapp/fragments/PhotoFragment.java
@@ -7,6 +7,7 @@ import android.appwidget.AppWidgetManager;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.graphics.text.LineBreaker;
@@ -646,6 +647,9 @@ public class PhotoFragment extends Fragment {
         dialog.show();
 
         isDialogShown = true;
+        if (getActivity() != null) {
+            getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+        }
 
         YouTubePlayerView fullScreenVideoPlayerView = dialog.findViewById(R.id.youtube_player_view);
         getLifecycle().addObserver(fullScreenVideoPlayerView);
@@ -661,6 +665,8 @@ public class PhotoFragment extends Fragment {
                 Toast.makeText(getActivity(), getString(R.string.video_not_playable), Toast.LENGTH_SHORT).show();
                 Log.e(LOG_TAG, "Failed to open a video with URL " + videoId + error.name());
                 super.onError(youTubePlayer, error);
+                isDialogShown = false;
+                dialog.dismiss();
             }
         });
 
@@ -672,6 +678,9 @@ public class PhotoFragment extends Fragment {
         dialog.setOnDismissListener(dialog -> {
             isDialogShown = false;
             fullScreenVideoPlayerView.release();
+            if (getActivity() != null) {
+                getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER);
+            }
         });
     }
 

--- a/app/src/main/java/com/udacity/astroapp/fragments/PhotoFragment.java
+++ b/app/src/main/java/com/udacity/astroapp/fragments/PhotoFragment.java
@@ -28,6 +28,7 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.ScrollView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -459,7 +460,12 @@ public class PhotoFragment extends Fragment {
                     playVideoButton.setOnClickListener(view -> {
                         if (getActivity() != null) {
                             Intent intent = YouTubeStandalonePlayer.createVideoIntent(getActivity(), YOUTUBE_API_KEY, videoId, 0, true, true);
-                            startActivity(intent);
+                            try {
+                                startActivity(intent);
+                            } catch (Exception e) {
+                                Toast.makeText(getActivity(), getString(R.string.video_not_playable), Toast.LENGTH_SHORT).show();
+                                Log.e(LOG_TAG, "Failed to open a video with URL" + videoId, e);
+                            }
                         }
                     });
                 } else {
@@ -563,7 +569,7 @@ public class PhotoFragment extends Fragment {
         }
     }
 
-    private void showEmptyView(){
+    private void showEmptyView() {
         loadingIndicator.setVisibility(View.GONE);
         photoTitleTextView.setVisibility(View.GONE);
         photoDescriptionTextView.setVisibility(View.GONE);

--- a/app/src/main/res/layout/fullscreen_video.xml
+++ b/app/src/main/res/layout/fullscreen_video.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fullscreen_video_frame_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
+        android:id="@+id/youtube_player_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+      />
+</FrameLayout>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -14,7 +14,7 @@
     <string name="diameter_label">Promjer:</string>
     <string name="dismiss_dialog">Zatvori</string>
     <string name="grant_location_permission">Dopusti pristup lokaciji</string>
-    <string name="video_not_playable">Nema dostupnih aplikacija za prikazati videozapis</string>
+    <string name="video_not_playable">Problem s prikazom videozapisa</string>
     <string name="location_access_not_granted_toast">Trebamo Vaše dopuštenje s ciljem korištenja Vaše lokacije za pronalaženje zvjezdarnica u Vašoj blizini. Molimo dopustite pristup lokaciji u postavkama Vašeg telefona.</string>
     <string name="location_permission_declined">Odbijeno dopuštenje pristupa lokaciji</string>
     <string name="location_permission_granted">Dopušten pristup lokaciji</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -14,6 +14,7 @@
     <string name="diameter_label">Promjer:</string>
     <string name="dismiss_dialog">Zatvori</string>
     <string name="grant_location_permission">Dopusti pristup lokaciji</string>
+    <string name="video_not_playable">Nema dostupnih aplikacija za prikazati videozapis</string>
     <string name="location_access_not_granted_toast">Trebamo Vaše dopuštenje s ciljem korištenja Vaše lokacije za pronalaženje zvjezdarnica u Vašoj blizini. Molimo dopustite pristup lokaciji u postavkama Vašeg telefona.</string>
     <string name="location_permission_declined">Odbijeno dopuštenje pristupa lokaciji</string>
     <string name="location_permission_granted">Dopušten pristup lokaciji</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
     <string name="location_permission_granted">Location permission granted</string>
     <string name="location_permission_declined">Location permission not granted</string>
     <string name="grant_location_permission">Grant location permission</string>
-    <string name="video_not_playable">No apps available to display the video</string>
+    <string name="video_not_playable">Failed to display the video</string>
 
     <!-- ObservatoryFragment strings -->
     <string name="observatory_fragment_name" translatable="false">ObservatoryFragment</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,7 @@
     <string name="location_permission_granted">Location permission granted</string>
     <string name="location_permission_declined">Location permission not granted</string>
     <string name="grant_location_permission">Grant location permission</string>
+    <string name="video_not_playable">No apps available to display the video</string>
 
     <!-- ObservatoryFragment strings -->
     <string name="observatory_fragment_name" translatable="false">ObservatoryFragment</string>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.4.2'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip


### PR DESCRIPTION
- Fix crash in PhotoFragment if the video cannot be opened and in that case display a toast with the error message
- Replace the deprecated YoutubeStandalonePlayer with android-youtube-player
- Change to landscape orientation when a video in PhotoFragment is displayed
- Update compile and target SDK versions to 35 and update versions accordingly
- Remove unneccessary WRITE_EXTERNAL_STORAGE permission from AndroidManifest and set the READ_EXTERNAL_STORAGE permission's maxSdkVersion to 32